### PR TITLE
JBIDE-19162 add openshift v3 feature to jbosstools updatesite

### DIFF
--- a/aggregate/coretests-site/category.xml
+++ b/aggregate/coretests-site/category.xml
@@ -31,10 +31,10 @@
 <feature id="org.jboss.tools.jst.test.feature"><category name="JBoss Tools - Core Tests"/></feature>
 <feature id="org.jboss.tools.maven.test.feature"><category name="JBoss Tools - Core Tests"/></feature>
 <feature id="org.jboss.tools.openshift.express.test.feature"><category name="JBoss Tools - Core Tests"/></feature>
+<feature id="org.jboss.tools.openshift.test.feature"><category name="JBoss Tools - Core Tests"/></feature>
 <feature id="org.jboss.tools.portlet.test.feature"><category name="JBoss Tools - Core Tests"/></feature>
 <feature id="org.jboss.tools.runtime.test.feature"><category name="JBoss Tools - Core Tests"/></feature>
 <feature id="org.jboss.tools.seam.test.feature"><category name="JBoss Tools - Core Tests"/></feature>
-<!-- JBIDE-13618 remove struts <feature id="org.jboss.tools.struts.test.feature"><category name="JBoss Tools - Core Tests"/></feature> -->
 <feature id="org.jboss.tools.foundation.test.feature"><category name="JBoss Tools - Core Tests"/></feature>
 <feature id="org.jboss.tools.stacks.core.test.feature"><category name="JBoss Tools - Core Tests"/></feature>
 <feature id="org.jboss.tools.test.feature"><category name="JBoss Tools - Core Tests"/></feature>
@@ -64,10 +64,10 @@
 <feature id="org.jboss.tools.jst.test.feature.source"><category name="JBoss Tools - Core Tests"/></feature>
 <feature id="org.jboss.tools.maven.test.feature.source"><category name="JBoss Tools - Core Tests"/></feature>
 <feature id="org.jboss.tools.openshift.express.test.feature.source"><category name="JBoss Tools - Core Tests"/></feature>
+<feature id="org.jboss.tools.openshift.test.feature.source"><category name="JBoss Tools - Core Tests"/></feature>
 <feature id="org.jboss.tools.portlet.test.feature.source"><category name="JBoss Tools - Core Tests"/></feature>
 <feature id="org.jboss.tools.runtime.test.feature.source"><category name="JBoss Tools - Core Tests"/></feature>
 <feature id="org.jboss.tools.seam.test.feature.source"><category name="JBoss Tools - Core Tests"/></feature>
-<!-- JBIDE-13618 remove struts <feature id="org.jboss.tools.struts.test.feature.source"><category name="JBoss Tools - Core Tests"/></feature> -->
 <feature id="org.jboss.tools.test.feature.source"><category name="JBoss Tools - Core Tests"/></feature>
 <feature id="org.jboss.tools.usage.test.feature.source"><category name="JBoss Tools - Core Tests"/></feature>
 <feature id="org.jboss.tools.vpe.test.feature.source"><category name="JBoss Tools - Core Tests"/></feature>

--- a/aggregate/site/category.xml
+++ b/aggregate/site/category.xml
@@ -102,6 +102,10 @@
     <category name="CoreTools" />
     <category name="CloudTools" />
   </feature>
+  <feature id="org.jboss.tools.openshift.feature">
+    <category name="CoreTools" />
+    <category name="CloudTools" />
+  </feature>
   <feature id="org.jboss.ide.eclipse.archives.feature">
     <category name="CoreTools" />
     <category name="GeneralTools" />
@@ -297,6 +301,7 @@
   <feature id="org.jboss.tools.cdi.deltaspike.feature.source"/>
   <feature id="org.jboss.tools.jmx.feature.source"/>
   <feature id="org.jboss.ide.eclipse.as.feature.source"/>
+  <feature id="org.jboss.tools.openshift.feature.source"/>
   <feature id="org.jboss.tools.openshift.express.feature.source"/>
   <feature id="org.jboss.tools.openshift.egit.integration.feature.source"/>
   <feature id="org.jboss.ide.eclipse.archives.feature.source"/>


### PR DESCRIPTION
This should *not* be done before jbosstools/jbosstools-openshift v3 have been merged to master.