### PR TITLE
Avoid aggregate to depend on previous build of aggregate.

### DIFF
--- a/aggregate/central-site/pom.xml
+++ b/aggregate/central-site/pom.xml
@@ -135,5 +135,13 @@
       </build>
     </profile>
   </profiles>
+  
+  <repositories>
+    <repository>
+      <id>jbosstools-site</id>
+      <layout>p2</layout>
+      <url>${jbosstools-site}</url>
+    </repository>
+  </repositories>
 
 </project>

--- a/aggregate/earlyaccess-site/pom.xml
+++ b/aggregate/earlyaccess-site/pom.xml
@@ -136,4 +136,12 @@
     </profile>
   </profiles>
 
+  <repositories>
+    <repository>
+      <id>jbosstools-site</id>
+      <layout>p2</layout>
+      <url>${jbosstools-site}</url>
+    </repository>
+  </repositories>
+
 </project>

--- a/aggregate/pom.xml
+++ b/aggregate/pom.xml
@@ -92,11 +92,4 @@
 
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>jbosstools-site</id>
-      <layout>p2</layout>
-      <url>${jbosstools-site}</url>
-    </repository>
-  </repositories>
 </project>

--- a/aggregate/webtools-site/pom.xml
+++ b/aggregate/webtools-site/pom.xml
@@ -100,4 +100,12 @@
 
   </profiles>
 
+  <repositories>
+    <repository>
+      <id>jbosstools-site</id>
+      <layout>p2</layout>
+      <url>${jbosstools-site}</url>
+    </repository>
+  </repositories>
+
 </project>


### PR DESCRIPTION
Move reference to aggregate repository to individual modules that
actually require it.