### PR TITLE
JBIDE-24240 / EBZ 511793 add...

### DIFF
--- a/aggregate/site/category.xml
+++ b/aggregate/site/category.xml
@@ -44,6 +44,13 @@
   </bundle>
   <bundle id="org.yaml.snakeyaml"/>
 
+  <!-- https://issues.jboss.org/browse/JBIDE-24240 / EBZ 511793 org.eclipse.wst.common.modulecore patch feature -->
+  <feature id="org.eclipse.wst.common_core_EBZ511793.feature.patch">
+    <category name="CoreTools" />
+    <category name="WebTools" />
+    <category name="Patches" />
+  </feature>
+
   <!-- JBDS-3898 JSON editor -->
   <feature id="org.eclipse.wst.json_core.feature">
     <category name="CoreTools" />
@@ -492,4 +499,9 @@
   <category-def name="CloudContainerTools" label="JBoss Cloud And Container Development Tools">
     <description>Tools for Cloud and Container Development.</description>
   </category-def>
+
+  <category-def name="Patches" label="Patches">
+    <description>Patch features for Eclipse or Eclipse projects.</description>
+  </category-def>
+
 </site>


### PR DESCRIPTION
JBIDE-24240 / EBZ 511793 add org.eclipse.wst.common.modulecore patch feature to JBT Abridged category (CoreTools) and WebTools too
add org.eclipse.wst.common_core_EBZ511793.feature.patch to patches category too (JBIDE-24240)

Signed-off-by: nickboldt <nboldt@redhat.com>