### PR TITLE
JBIDE-27855: add missing jdt.core bundle to core updatesite.

### DIFF
--- a/aggregate/site/category.xml
+++ b/aggregate/site/category.xml
@@ -275,6 +275,7 @@
   <feature id="org.jboss.tools.quarkus.feature">
     <category name="CoreTools" />
   </feature>
+  <bundle id="org.eclipse.lsp4mp.jdt.core"/>
 
   <!-- include but do not categorize -->
   <feature id="org.jboss.tools.central.feature"/>


### PR DESCRIPTION
Signed-off-by: Stephane Bouchet <sbouchet@redhat.com>